### PR TITLE
Add a Window base class definition & clean up main()

### DIFF
--- a/src/editor/Window.cpp
+++ b/src/editor/Window.cpp
@@ -1,0 +1,33 @@
+#include "Window.h"
+
+Window::Window() {
+    name_ = "Name me!";
+    window_flags_ = 0;
+
+    // TODO: Elevate this to higher-level class once we have one
+    ImGuiStyle& style = ImGui::GetStyle();
+    style.WindowBorderSize = 0.0f;
+    style.FrameBorderSize = 1.0f;
+    style.ScrollbarRounding = 2.0f;
+    style.GrabRounding = 2.0f;
+    ImGui::StyleColorsLight();
+}
+
+void Window::Draw() {
+    SetPosition();
+    PreDraw();
+    ImGui::Begin(name_.c_str(), NULL, window_flags_);
+    DrawFrames();
+    ImGui::End();
+    PostDraw();
+}
+
+void Window::PreDraw(){
+	// No default implementation; override if needed
+    // I didn't want to make it pure virtual because it's not always needed,
+    // so why force y'all to implement it?
+}
+
+void Window::PostDraw() {
+	// Ditto
+}

--- a/src/editor/Window.h
+++ b/src/editor/Window.h
@@ -1,0 +1,52 @@
+/*
+	File: Window.h
+
+	Base class for all windows comprising the app's Editor. Provides a common interface
+	for these windows to be drawn. Also allows for polymorphic storage of windows.
+
+	Pure virtual functions are provided for necessary customizations of each window, 
+	such as positioning and drawing. Non-pure virtual functions are provided for 
+	optional customizations, such as any extra setup or cleanup required for drawing.
+
+	Some default, global ImGui customization options are also set here. This can help 
+	ensure a consistent look and feel across all windows. However, these options can
+	be overridden by derived classes.
+*/
+
+#ifndef WINDOW_H
+#define WINDOW_H
+
+#include <string>
+
+#include "imgui.h"
+
+class Window {
+ public:
+	Window();
+	Window(const Window&) = delete;
+	void operator=(const Window&) = delete;
+
+	// Main draw call for windows. Calls all virtual functions in correct order.
+	virtual void Draw() final;
+
+ protected:
+	// Set the Window's position and size. Used for responsive app resizing.
+	virtual void SetPosition() = 0;
+
+	// Perform any extra setup wanted (positioning, styling) before DrawFrames()
+	virtual void PreDraw();
+
+	// Draw the frames (aka, the inside content) of the window.
+	virtual void DrawFrames() = 0;
+
+	// Perform any cleanup necessary after DrawFrames()
+	virtual void PostDraw();
+
+	// The name of the window. Used for the title bar.
+	std::string name_;
+
+	// ImGui options for the window. 
+	ImGuiWindowFlags window_flags_;
+};
+
+#endif // WINDOW_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,35 +1,30 @@
 #include "imgui.h"
 #include "imgui-SFML.h"
-
 #include "SFML/Graphics.hpp"
-#include <box2d/box2d.h>
-#include <iostream>
+#include "box2d/box2d.h"
 
-void DrawPropertyWindow();
-
-int main()
-{
-    // Initialize
+int main() {
+    // Initialize SFML window
     sf::RenderWindow window(sf::VideoMode(1366, 768), "Gator Engine");
     window.setFramerateLimit(60);
+
+    // Initialize ImGui
     ImGui::SFML::Init(window);
     sf::Clock deltaClock;
 
-    while (window.isOpen())
-    {
+    while (window.isOpen()) {
         // Process user events
         sf::Event event;
-        while (window.pollEvent(event))
-        {
+        while (window.pollEvent(event)) {
             ImGui::SFML::ProcessEvent(window, event);
-            if (event.type == sf::Event::Closed)
+            if (event.type == sf::Event::Closed) {
                 window.close();
+            }
         }
 
         // Draw GUIs
         ImGui::SFML::Update(window, deltaClock.restart());
-        DrawPropertyWindow();
-
+        
         // Render updated window
         window.clear();
         ImGui::SFML::Render(window);
@@ -39,11 +34,4 @@ int main()
     // Clean up
     ImGui::SFML::Shutdown();
     return 0;
-}
-
-void DrawPropertyWindow()
-{
-	ImGui::Begin("Properties");
-	ImGui::Text("Placeholder for properties stuff");
-	ImGui::End();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,116 +4,46 @@
 #include "SFML/Graphics.hpp"
 #include <box2d/box2d.h>
 #include <iostream>
-// #include "glm.hpp"
+
+void DrawPropertyWindow();
 
 int main()
 {
+    // Initialize
     sf::RenderWindow window(sf::VideoMode(1366, 768), "Gator Engine");
-    // glm::bvec4 testVec(1, 0, 3, 4);
+    window.setFramerateLimit(60);
     ImGui::SFML::Init(window);
     sf::Clock deltaClock;
 
-    // Create world
-    b2Vec2 gravity(0.0f, -10.0f);
-    b2World world(gravity);
-    // Create a body def for the ground
-    b2BodyDef groundBodyDef;
-    groundBodyDef.position.Set(500, 500);
-    // Create a body using the def for the ground
-    b2Body *groundBody = world.CreateBody(&groundBodyDef);
-    // Create a polygon shape for the ground
-    b2PolygonShape groundBox;
-    groundBox.SetAsBox(50.0f, 50.0f);
-    // Give the ground physical properties
-    groundBody->CreateFixture(&groundBox, 0.0f);
-    // Create the sprite for the ground
-    sf::RectangleShape groundShape(sf::Vector2f(100.0f, 100.0f));
-    groundShape.setPosition(500, window.getSize().y - groundBody->GetPosition().y);
-    groundShape.setOrigin(sf::Vector2f(50, 50));
-    groundShape.setFillColor(sf::Color::Blue);
-
-    // Create a body def for the rigid body
-    b2BodyDef bodyDef;
-    bodyDef.type = b2_dynamicBody;
-    bodyDef.position.Set(500, 900);
-    // Create a body using the def for the rigid body
-    b2Body *body = world.CreateBody(&bodyDef);
-    // Create a polygon shape for the rigid body
-    b2PolygonShape dynamicBox;
-    dynamicBox.SetAsBox(5, 5);
-    // Give the rigid body physical properties
-    b2FixtureDef fixtureDef;
-    fixtureDef.shape = &dynamicBox;
-    fixtureDef.density = 1.0f;
-    fixtureDef.friction = 0.3f;
-    body->CreateFixture(&fixtureDef);
-
-    // Create the sprite for the rigid body
-    sf::RectangleShape boxShape(sf::Vector2f(10, 10));
-    boxShape.setPosition(500, window.getSize().y - body->GetPosition().y);
-    boxShape.setRotation(body->GetAngle());
-    boxShape.setOrigin(sf::Vector2f(5, 5));
-    boxShape.setFillColor(sf::Color::Red);
-
-    // Data for physics simulation steps
-    float timeStep = 1.0f / 60.0f;
-    int32 velocityIterations = 6;
-    int32 positionIterations = 2;
-
-    window.setFramerateLimit(60);
-    // Attach
-    float redBoxLength = 10;
-    float redBoxHeight = 10;
-    float redBoxX = 500;
-    float redBoxY = 768;
-
     while (window.isOpen())
     {
+        // Process user events
         sf::Event event;
         while (window.pollEvent(event))
         {
-            // Process ImGui gui events
-            ImGui::SFML::ProcessEvent(event);
+            ImGui::SFML::ProcessEvent(window, event);
             if (event.type == sf::Event::Closed)
                 window.close();
         }
-        // Update the ImGui visuals
+
+        // Draw GUIs
         ImGui::SFML::Update(window, deltaClock.restart());
-        ImGui::Begin("Red Square Size");
-        ImGui::Text("Drag the slider below to control red box size and position");
-        ImGui::SliderFloat("Length", &redBoxLength, 10, 300);
-        ImGui::SliderFloat("Height", &redBoxHeight, 10, 300);
+        DrawPropertyWindow();
 
-        // Update physics objects based on gui's
-        dynamicBox.SetAsBox(redBoxLength / 2, redBoxHeight / 2); // Updating size
-        // The position should only be updated if there is a change in the XPos/YPos slider
-        if (ImGui::SliderFloat("XPos", &redBoxX, 0, 1366))
-        {
-            body->SetTransform(b2Vec2(redBoxX, body->GetPosition().y), body->GetAngle()); // Updating x position
-            body->SetAwake(true);
-        }
-
-        if (ImGui::SliderFloat("YPos", &redBoxY, 0, 768))
-        {
-            body->SetTransform(b2Vec2(body->GetPosition().x, redBoxY), body->GetAngle()); // Updating y position
-            body->SetAwake(true);
-        }
-        ImGui::End();
-        // Run a physics step at 1/60 of a second
-        world.Step(timeStep, velocityIterations, positionIterations);
-        // Update sprite positions and rotations and sizes based on physics objects
-        boxShape.setPosition(body->GetPosition().x, window.getSize().y - body->GetPosition().y);
-        boxShape.setRotation(body->GetAngle());
-        boxShape.setSize(sf::Vector2f(redBoxLength, redBoxHeight));
-        boxShape.setOrigin(redBoxLength / 2, redBoxHeight / 2);
-
+        // Render updated window
         window.clear();
-        window.draw(groundShape);
-        window.draw(boxShape);
         ImGui::SFML::Render(window);
         window.display();
     }
 
+    // Clean up
     ImGui::SFML::Shutdown();
     return 0;
+}
+
+void DrawPropertyWindow()
+{
+	ImGui::Begin("Properties");
+	ImGui::Text("Placeholder for properties stuff");
+	ImGui::End();
 }


### PR DESCRIPTION
Adding an abstract base class, Window, for all windows (aka the panes) of the app's Editor to derive from. It defines a handful of virtual functions for derived classes (like the soon-to-be PropertyWindow) to implement on their own. 

This should be nice for polymorphism. We'd be able to draw all of our Editor via a vector of Window objects-- and with one neat call to Draw() for each.

I also cleaned up main() to be, like, the barebones version of main() with SFML and ImGui. Just to declutter. I might just remove it from the PR... it's not necessary

(My next PR will be the PropertyWindow definition, but I wanted to get this in first to shorten the full PR :)